### PR TITLE
[Feature] Add PhpStorm meta + make some constructor arguments required

### DIFF
--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -1,0 +1,56 @@
+<?php
+/*
+ * Protocol FCGI library
+ *
+ * @copyright Copyright 2021. Lisachenko Alexander <lisachenko.it@gmail.com>
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+declare(strict_types=1);
+
+namespace PHPSTORM_META;
+
+expectedArguments(
+    \Lisachenko\Protocol\FCGI\Record\BeginRequest::__construct(),
+    0,
+    \Lisachenko\Protocol\FCGI::RESPONDER,
+    \Lisachenko\Protocol\FCGI::AUTHORIZER,
+    \Lisachenko\Protocol\FCGI::FILTER,
+);
+
+expectedArguments(
+    \Lisachenko\Protocol\FCGI\Record\BeginRequest::__construct(),
+    1,
+    \Lisachenko\Protocol\FCGI::KEEP_CONN,
+);
+
+expectedArguments(
+    \Lisachenko\Protocol\FCGI\Record\EndRequest::__construct(),
+    0,
+    \Lisachenko\Protocol\FCGI::KEEP_CONN,
+    \Lisachenko\Protocol\FCGI::REQUEST_COMPLETE,
+    \Lisachenko\Protocol\FCGI::CANT_MPX_CONN,
+    \Lisachenko\Protocol\FCGI::OVERLOADED,
+    \Lisachenko\Protocol\FCGI::UNKNOWN_ROLE
+);
+
+expectedReturnValues(
+    \Lisachenko\Protocol\FCGI\Record::getVersion(),
+    \Lisachenko\Protocol\FCGI::VERSION_1
+);
+
+expectedReturnValues(
+    \Lisachenko\Protocol\FCGI\Record::getType(),
+    \Lisachenko\Protocol\FCGI::BEGIN_REQUEST,
+    \Lisachenko\Protocol\FCGI::ABORT_REQUEST,
+    \Lisachenko\Protocol\FCGI::END_REQUEST,
+    \Lisachenko\Protocol\FCGI::PARAMS,
+    \Lisachenko\Protocol\FCGI::STDIN,
+    \Lisachenko\Protocol\FCGI::STDOUT,
+    \Lisachenko\Protocol\FCGI::STDERR,
+    \Lisachenko\Protocol\FCGI::DATA,
+    \Lisachenko\Protocol\FCGI::GET_VALUES,
+    \Lisachenko\Protocol\FCGI::GET_VALUES_RESULT,
+    \Lisachenko\Protocol\FCGI::UNKNOWN_TYPE,
+);

--- a/src/FCGI.php
+++ b/src/FCGI.php
@@ -13,8 +13,6 @@ namespace Lisachenko\Protocol;
 
 /**
  * FCGI constants.
- *
- * @author Alexander.Lisachenko
  */
 class FCGI
 {

--- a/src/FCGI/FrameParser.php
+++ b/src/FCGI/FrameParser.php
@@ -15,8 +15,6 @@ use Lisachenko\Protocol\FCGI;
 
 /**
  * Utility class to simplify parsing of FCGI protocol data.
- *
- * @author Alexander.Lisachenko
  */
 class FrameParser
 {

--- a/src/FCGI/Record.php
+++ b/src/FCGI/Record.php
@@ -16,8 +16,6 @@ use ReflectionClass;
 
 /**
  * FCGI record.
- *
- * @author Alexander.Lisachenko
  */
 class Record
 {

--- a/src/FCGI/Record/AbortRequest.php
+++ b/src/FCGI/Record/AbortRequest.php
@@ -16,8 +16,6 @@ use Lisachenko\Protocol\FCGI\Record;
 
 /**
  * The Web server sends a FCGI_ABORT_REQUEST record to abort a request
- *
- * @author Alexander.Lisachenko
  */
 class AbortRequest extends Record
 {

--- a/src/FCGI/Record/AbortRequest.php
+++ b/src/FCGI/Record/AbortRequest.php
@@ -19,7 +19,7 @@ use Lisachenko\Protocol\FCGI\Record;
  */
 class AbortRequest extends Record
 {
-    public function __construct(int $requestId = 0)
+    public function __construct(int $requestId)
     {
         $this->type = FCGI::ABORT_REQUEST;
         $this->setRequestId($requestId);

--- a/src/FCGI/Record/BeginRequest.php
+++ b/src/FCGI/Record/BeginRequest.php
@@ -16,8 +16,6 @@ use Lisachenko\Protocol\FCGI\Record;
 
 /**
  * The Web server sends a FCGI_BEGIN_REQUEST record to start a request.
- *
- * @author Alexander.Lisachenko
  */
 class BeginRequest extends Record
 {

--- a/src/FCGI/Record/Data.php
+++ b/src/FCGI/Record/Data.php
@@ -21,7 +21,7 @@ use Lisachenko\Protocol\FCGI\Record;
  */
 class Data extends Record
 {
-    public function __construct(string $contentData = '')
+    public function __construct(string $contentData)
     {
         $this->type = FCGI::DATA;
         $this->setContentData($contentData);

--- a/src/FCGI/Record/Data.php
+++ b/src/FCGI/Record/Data.php
@@ -18,8 +18,6 @@ use Lisachenko\Protocol\FCGI\Record;
  * Data binary stream
  *
  * FCGI_DATA is a second stream record type used to send additional data to the application.
- *
- * @author Alexander.Lisachenko
  */
 class Data extends Record
 {

--- a/src/FCGI/Record/EndRequest.php
+++ b/src/FCGI/Record/EndRequest.php
@@ -17,8 +17,6 @@ use Lisachenko\Protocol\FCGI\Record;
 /**
  * The application sends a FCGI_END_REQUEST record to terminate a request, either because the application
  * has processed the request or because the application has rejected the request.
- *
- * @author Alexander.Lisachenko
  */
 class EndRequest extends Record
 {

--- a/src/FCGI/Record/GetValues.php
+++ b/src/FCGI/Record/GetValues.php
@@ -42,7 +42,7 @@ class GetValues extends Params
      *
      * @phpstan-param list<string> $keys
      */
-    public function __construct(array $keys = [])
+    public function __construct(array $keys)
     {
         parent::__construct(array_fill_keys($keys, ''));
         $this->type = FCGI::GET_VALUES;

--- a/src/FCGI/Record/GetValues.php
+++ b/src/FCGI/Record/GetValues.php
@@ -32,8 +32,6 @@ use Lisachenko\Protocol\FCGI;
  *   FCGI_MAX_REQS:   The maximum number of concurrent requests this application will accept, e.g. "1" or "50".
  *   FCGI_MPXS_CONNS: "0" if this application does not multiplex connections (i.e. handle concurrent requests
  *                    over each connection), "1" otherwise.
- *
- * @author Alexander.Lisachenko
  */
 class GetValues extends Params
 {

--- a/src/FCGI/Record/GetValuesResult.php
+++ b/src/FCGI/Record/GetValuesResult.php
@@ -32,8 +32,6 @@ use Lisachenko\Protocol\FCGI;
  *   FCGI_MAX_REQS:   The maximum number of concurrent requests this application will accept, e.g. "1" or "50".
  *   FCGI_MPXS_CONNS: "0" if this application does not multiplex connections (i.e. handle concurrent requests
  *                    over each connection), "1" otherwise.
- *
- * @author Alexander.Lisachenko
  */
 class GetValuesResult extends Params
 {

--- a/src/FCGI/Record/GetValuesResult.php
+++ b/src/FCGI/Record/GetValuesResult.php
@@ -40,7 +40,7 @@ class GetValuesResult extends Params
      *
      * @phpstan-param array<string, string> $values
      */
-    public function __construct(array $values = [])
+    public function __construct(array $values)
     {
         parent::__construct($values);
         $this->type = FCGI::GET_VALUES_RESULT;

--- a/src/FCGI/Record/Params.php
+++ b/src/FCGI/Record/Params.php
@@ -16,8 +16,6 @@ use Lisachenko\Protocol\FCGI\Record;
 
 /**
  * Params request record
- *
- * @author Alexander.Lisachenko
  */
 class Params extends Record
 {

--- a/src/FCGI/Record/Params.php
+++ b/src/FCGI/Record/Params.php
@@ -32,7 +32,7 @@ class Params extends Record
      *
      * @phpstan-param array<string, string> $values
      */
-    public function __construct(array $values = [])
+    public function __construct(array $values)
     {
         $this->type   = FCGI::PARAMS;
         $this->values = $values;

--- a/src/FCGI/Record/Stderr.php
+++ b/src/FCGI/Record/Stderr.php
@@ -21,7 +21,7 @@ use Lisachenko\Protocol\FCGI\Record;
  */
 class Stderr extends Record
 {
-    public function __construct(string $contentData = '')
+    public function __construct(string $contentData)
     {
         $this->type = FCGI::STDERR;
         $this->setContentData($contentData);

--- a/src/FCGI/Record/Stderr.php
+++ b/src/FCGI/Record/Stderr.php
@@ -18,8 +18,6 @@ use Lisachenko\Protocol\FCGI\Record;
  * Stderr binary stream
  *
  * FCGI_STDERR is a stream record for sending arbitrary data from the application to the Web server
- *
- * @author Alexander.Lisachenko
  */
 class Stderr extends Record
 {

--- a/src/FCGI/Record/Stdin.php
+++ b/src/FCGI/Record/Stdin.php
@@ -21,7 +21,7 @@ use Lisachenko\Protocol\FCGI\Record;
  */
 class Stdin extends Record
 {
-    public function __construct(string $contentData = '')
+    public function __construct(string $contentData)
     {
         $this->type = FCGI::STDIN;
         $this->setContentData($contentData);

--- a/src/FCGI/Record/Stdin.php
+++ b/src/FCGI/Record/Stdin.php
@@ -18,8 +18,6 @@ use Lisachenko\Protocol\FCGI\Record;
  * Stdin binary stream
  *
  * FCGI_STDIN is a stream record type used in sending arbitrary data from the Web server to the application
- *
- * @author Alexander.Lisachenko
  */
 class Stdin extends Record
 {

--- a/src/FCGI/Record/Stdout.php
+++ b/src/FCGI/Record/Stdout.php
@@ -18,8 +18,6 @@ use Lisachenko\Protocol\FCGI\Record;
  * Stdout binary stream
  *
  * FCGI_STDOUT is a stream record for sending arbitrary data from the application to the Web server
- *
- * @author Alexander.Lisachenko
  */
 class Stdout extends Record
 {

--- a/src/FCGI/Record/Stdout.php
+++ b/src/FCGI/Record/Stdout.php
@@ -21,7 +21,7 @@ use Lisachenko\Protocol\FCGI\Record;
  */
 class Stdout extends Record
 {
-    public function __construct(string $contentData = '')
+    public function __construct(string $contentData)
     {
         $this->type = FCGI::STDOUT;
         $this->setContentData($contentData);

--- a/src/FCGI/Record/UnknownType.php
+++ b/src/FCGI/Record/UnknownType.php
@@ -34,7 +34,7 @@ class UnknownType extends Record
      */
     protected string $reserved1;
 
-    public function __construct(int $type = 0, string $reserved = '')
+    public function __construct(int $type, string $reserved = '')
     {
         $this->type      = FCGI::UNKNOWN_TYPE;
         $this->type1     = $type;

--- a/src/FCGI/Record/UnknownType.php
+++ b/src/FCGI/Record/UnknownType.php
@@ -21,8 +21,6 @@ use Lisachenko\Protocol\FCGI\Record;
  * To provide for this evolution, the protocol includes the FCGI_UNKNOWN_TYPE management record.
  * When an application receives a management record whose type T it does not understand, the application responds
  * with {FCGI_UNKNOWN_TYPE, 0, {T}}.
- *
- * @author Alexander.Lisachenko
  */
 class UnknownType extends Record
 {

--- a/tests/FCGI/FrameParserTest.php
+++ b/tests/FCGI/FrameParserTest.php
@@ -15,9 +15,6 @@ use PHPUnit\Framework\TestCase;
 use Lisachenko\Protocol\FCGI\Record\BeginRequest;
 use Lisachenko\Protocol\FCGI\Record\Params;
 
-/**
- * @author Alexander.Lisachenko
- */
 class FrameParserTest extends TestCase
 {
     public function testHasFrame(): void

--- a/tests/FCGI/Record/AbortRequestTest.php
+++ b/tests/FCGI/Record/AbortRequestTest.php
@@ -14,9 +14,6 @@ namespace Lisachenko\Protocol\FCGI\Record;
 use PHPUnit\Framework\TestCase;
 use Lisachenko\Protocol\FCGI;
 
-/**
- * @author Alexander.Lisachenko
- */
 class AbortRequestTest extends TestCase
 {
     protected static string $rawMessage = '0102000100000000';

--- a/tests/FCGI/Record/BeginRequestTest.php
+++ b/tests/FCGI/Record/BeginRequestTest.php
@@ -14,9 +14,6 @@ namespace Lisachenko\Protocol\FCGI\Record;
 use PHPUnit\Framework\TestCase;
 use Lisachenko\Protocol\FCGI;
 
-/**
- * @author Alexander.Lisachenko
- */
 class BeginRequestTest extends TestCase
 {
     protected static string $rawMessage = '01010000000800000001010000000000';

--- a/tests/FCGI/Record/DataTest.php
+++ b/tests/FCGI/Record/DataTest.php
@@ -14,9 +14,6 @@ namespace Lisachenko\Protocol\FCGI\Record;
 use PHPUnit\Framework\TestCase;
 use Lisachenko\Protocol\FCGI;
 
-/**
- * @author Alexander.Lisachenko
- */
 class DataTest extends TestCase
 {
     protected static string $rawMessage = '01080000000404007465737400000000';

--- a/tests/FCGI/Record/EndRequestTest.php
+++ b/tests/FCGI/Record/EndRequestTest.php
@@ -14,9 +14,6 @@ namespace Lisachenko\Protocol\FCGI\Record;
 use PHPUnit\Framework\TestCase;
 use Lisachenko\Protocol\FCGI;
 
-/**
- * @author Alexander.Lisachenko
- */
 class EndRequestTest extends TestCase
 {
     protected static string $rawMessage = '01030000000800000000006400000000';

--- a/tests/FCGI/Record/GetValuesResultTest.php
+++ b/tests/FCGI/Record/GetValuesResultTest.php
@@ -14,9 +14,6 @@ namespace Lisachenko\Protocol\FCGI\Record;
 use PHPUnit\Framework\TestCase;
 use Lisachenko\Protocol\FCGI;
 
-/**
- * @author Alexander.Lisachenko
- */
 class GetValuesResultTest extends TestCase
 {
     protected static string $rawMessage = '010a0000001206000f01464347495f4d5058535f434f4e4e5331000000000000';

--- a/tests/FCGI/Record/GetValuesTest.php
+++ b/tests/FCGI/Record/GetValuesTest.php
@@ -14,9 +14,6 @@ namespace Lisachenko\Protocol\FCGI\Record;
 use PHPUnit\Framework\TestCase;
 use Lisachenko\Protocol\FCGI;
 
-/**
- * @author Alexander.Lisachenko
- */
 class GetValuesTest extends TestCase
 {
     protected static string $rawMessage = '01090000001107000f00464347495f4d5058535f434f4e4e5300000000000000';

--- a/tests/FCGI/Record/ParamsTest.php
+++ b/tests/FCGI/Record/ParamsTest.php
@@ -14,9 +14,6 @@ namespace Lisachenko\Protocol\FCGI\Record;
 use Lisachenko\Protocol\FCGI;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @author Alexander.Lisachenko
- */
 class ParamsTest extends TestCase
 {
     protected static string $rawMessage ='

--- a/tests/FCGI/Record/StderrTest.php
+++ b/tests/FCGI/Record/StderrTest.php
@@ -14,9 +14,6 @@ namespace Lisachenko\Protocol\FCGI\Record;
 use PHPUnit\Framework\TestCase;
 use Lisachenko\Protocol\FCGI;
 
-/**
- * @author Alexander.Lisachenko
- */
 class StderrTest extends TestCase
 {
     protected static string $rawMessage = '01070000000404007465737400000000';

--- a/tests/FCGI/Record/StdinTest.php
+++ b/tests/FCGI/Record/StdinTest.php
@@ -14,9 +14,6 @@ namespace Lisachenko\Protocol\FCGI\Record;
 use PHPUnit\Framework\TestCase;
 use Lisachenko\Protocol\FCGI;
 
-/**
- * @author Alexander.Lisachenko
- */
 class StdinTest extends TestCase
 {
     protected static string $rawMessage = '01050000000404007465737400000000';

--- a/tests/FCGI/Record/StdoutTest.php
+++ b/tests/FCGI/Record/StdoutTest.php
@@ -14,9 +14,6 @@ namespace Lisachenko\Protocol\FCGI\Record;
 use PHPUnit\Framework\TestCase;
 use Lisachenko\Protocol\FCGI;
 
-/**
- * @author Alexander.Lisachenko
- */
 class StdoutTest extends TestCase
 {
     protected static string $rawMessage = '01060000000404007465737400000000';

--- a/tests/FCGI/Record/UnknownTypeTest.php
+++ b/tests/FCGI/Record/UnknownTypeTest.php
@@ -14,9 +14,6 @@ namespace Lisachenko\Protocol\FCGI\Record;
 use PHPUnit\Framework\TestCase;
 use Lisachenko\Protocol\FCGI;
 
-/**
- * @author Alexander.Lisachenko
- */
 class UnknownTypeTest extends TestCase
 {
     protected static string $rawMessage = '010b0000000800002a57544621000000';

--- a/tests/FCGI/RecordTest.php
+++ b/tests/FCGI/RecordTest.php
@@ -14,9 +14,6 @@ namespace Lisachenko\Protocol\FCGI;
 use PHPUnit\Framework\TestCase;
 use Lisachenko\Protocol\FCGI;
 
-/**
- * @author Alexander.Lisachenko
- */
 class RecordTest extends TestCase
 {
     // from the wireshark captured traffic


### PR DESCRIPTION
Some of record constructors have default values even for required arguments, need to remove default values, make them required.

Also, to improve IDE support, `.phpstorm.meta.php` file can be added.