### PR TITLE
chore: raise PHPStan to level max

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-  level: 8
+  level: max
   paths:
     - src
     - tests

--- a/tests/FCGI/Record/ParamsTest.php
+++ b/tests/FCGI/Record/ParamsTest.php
@@ -22,7 +22,7 @@ class ParamsTest extends TestCase
         4152455048502f50726f746f636f6c2d464347490000000000';
 
     /**
-     * @var string[]
+     * @var array<string, string>
      */
     protected static array $params = [
         'SCRIPT_FILENAME'   => '/home/test.php',


### PR DESCRIPTION
## Summary

**PR 4/6 of the library refresh stack** (agent docs ✅ → README ✅ → toolchain #101 → **PHPStan max** → PHP 8.4 modernization → CHANGELOG). Based on `chore/modernize-toolchain` — merge #101 first.

- `phpstan.neon`: `level: 8` → `level: max` (level 10 on PHPStan 2), matching the README's PHPStan badge. Analysis still covers both `src/` and `tests/`.
- The entire codebase needed exactly one fix at max: the `ParamsTest` fixture annotation tightened from `string[]` to `array<string, string>` to match the `Params` constructor's parameter type.

This PR intentionally lands before the PHP 8.4 modernization so the refactor starts from the strictest baseline.

## Test plan

Verified locally on PHP 8.4.19: `composer phpstan` — 0 errors at level max; `composer test` — 27 tests, 80 assertions green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PX3K7p5AYfoVmtED88AAKv)_