### PR TITLE
refactor!: modernize the library with PHP 8.4 features and enums

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,8 @@ low-level building blocks (records and a frame parser) for writing FastCGI clien
 | Path | Purpose |
 |------|---------|
 | `src/FCGI.php` | Protocol-level constants (header length/format, version, flags) |
+| `src/FCGI/RecordType.php`, `Role.php`, `ProtocolStatus.php` | Int-backed enums for the protocol vocabulary; `RecordType::recordClass()` maps types to record classes |
+| `src/FCGI/ProtocolException.php` | Thrown on malformed/truncated buffers and invalid wire values |
 | `src/FCGI/Record.php` | Base record: header pack/unpack, payload handling, `__toString()` emits wire bytes |
 | `src/FCGI/FrameParser.php` | Turns a binary buffer into typed `Record` instances (`hasFrame()` / `parseFrame()`) |
 | `src/FCGI/Record/*.php` | One class per FCGI record type (BeginRequest, EndRequest, Params, Stdin, Stdout, Stderr, Data, AbortRequest, GetValues, GetValuesResult, UnknownType) |
@@ -61,6 +63,9 @@ This library implements a binary network protocol. Byte layouts must never chang
   parsed frame.
 - Unpacking creates records **without invoking constructors** (hydration), so the raw
   wire bytes are preserved exactly even for legal-but-non-canonical peer encodings.
+  Record-specific fields are hydrated by the protected instance method
+  `unpackPayload()`; keep class-level property defaults (not constructor promotion)
+  for any field that must survive a zero-length payload (see `Params::$values`).
 - `Params` name-value pairs use variable-length encoding: 1-byte lengths for < 128,
   4-byte lengths (high bit set) otherwise.
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ and **servers** (long-running PHP daemons that nginx can speak to natively).
   recommends
 - 🏷️ **Full name-value pair encoding** — including the 4-byte long form for names and
   values over 127 bytes
+- 🎯 **Native enums for the protocol vocabulary** — record types, roles and protocol
+  statuses are backed enums (`RecordType`, `Role`, `ProtocolStatus`), so invalid wire
+  values fail fast with a dedicated `ProtocolException`
 - 🪶 **Zero runtime dependencies** — pure PHP, nothing but the language itself
 - 🔒 **Strict types + PHPStan at the maximum level** — the whole codebase (tests
   included) passes static analysis at the strictest setting
@@ -54,13 +57,13 @@ available at [fast-cgi.github.io/spec](https://fast-cgi.github.io/spec).
 ```php
 <?php
 
-use Lisachenko\Protocol\FCGI;
 use Lisachenko\Protocol\FCGI\FrameParser;
 use Lisachenko\Protocol\FCGI\Record\BeginRequest;
 use Lisachenko\Protocol\FCGI\Record\EndRequest;
 use Lisachenko\Protocol\FCGI\Record\Params;
 use Lisachenko\Protocol\FCGI\Record\Stdin;
 use Lisachenko\Protocol\FCGI\Record\Stdout;
+use Lisachenko\Protocol\FCGI\Role;
 
 include 'vendor/autoload.php';
 
@@ -70,7 +73,7 @@ $phpSocket = fsockopen('127.0.0.1', 9001, $errorNumber, $errorString);
 // Prepare the request: begin, pass parameters, then close the input stream.
 // Empty Params and Stdin records mark the end of the corresponding stream.
 $packet  = '';
-$packet .= new BeginRequest(FCGI::RESPONDER);
+$packet .= new BeginRequest(Role::Responder);
 $packet .= new Params(['SCRIPT_FILENAME' => '/var/www/some_file.php']);
 $packet .= new Params([]);
 $packet .= new Stdin('');

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-  level: 8
+  level: max
   paths:
     - src
     - tests

--- a/src/FCGI.php
+++ b/src/FCGI.php
@@ -12,9 +12,12 @@ declare(strict_types=1);
 namespace Lisachenko\Protocol;
 
 /**
- * FCGI constants.
+ * FCGI protocol constants.
+ *
+ * Record types, roles and protocol statuses are represented by the native enums
+ * {@see FCGI\RecordType}, {@see FCGI\Role} and {@see FCGI\ProtocolStatus}.
  */
-class FCGI
+final class FCGI
 {
     /**
      * Number of bytes in a FCGI_Header.  Future versions of the protocol
@@ -33,22 +36,6 @@ class FCGI
     public const VERSION_1 = 1;
 
     /**
-     * Values for type component of FCGI_Header
-     */
-    public const
-        BEGIN_REQUEST = 1,
-        ABORT_REQUEST = 2,
-        END_REQUEST = 3,
-        PARAMS = 4,
-        STDIN = 5,
-        STDOUT = 6,
-        STDERR = 7,
-        DATA = 8,
-        GET_VALUES = 9,
-        GET_VALUES_RESULT = 10,
-        UNKNOWN_TYPE = 11;
-
-    /**
      * Value for requestId component of FCGI_Header
      */
     public const NULL_REQUEST_ID = 0;
@@ -59,20 +46,9 @@ class FCGI
     public const KEEP_CONN = 1;
 
     /**
-     * Values for role component of FCGI_BeginRequestBody
+     * This is a static holder of protocol constants, it can not be instantiated.
      */
-    public const
-        RESPONDER = 1,
-        AUTHORIZER = 2,
-        FILTER = 3;
-
-    /**
-     * Values for protocolStatus component of FCGI_EndRequestBody
-     */
-    public const
-        REQUEST_COMPLETE = 0,
-        CANT_MPX_CONN = 1,
-        OVERLOADED = 2,
-        UNKNOWN_ROLE = 3;
-
+    private function __construct()
+    {
+    }
 }

--- a/src/FCGI/FrameParser.php
+++ b/src/FCGI/FrameParser.php
@@ -16,26 +16,8 @@ use Lisachenko\Protocol\FCGI;
 /**
  * Utility class to simplify parsing of FCGI protocol data.
  */
-class FrameParser
+final class FrameParser
 {
-    /**
-     * Mapping of constants to the classes
-     * @phpstan-var array<int, class-string>
-     */
-    protected static array $classMapping = [
-        FCGI::BEGIN_REQUEST     => FCGI\Record\BeginRequest::class,
-        FCGI::ABORT_REQUEST     => FCGI\Record\AbortRequest::class,
-        FCGI::END_REQUEST       => FCGI\Record\EndRequest::class,
-        FCGI::PARAMS            => FCGI\Record\Params::class,
-        FCGI::STDIN             => FCGI\Record\Stdin::class,
-        FCGI::STDOUT            => FCGI\Record\Stdout::class,
-        FCGI::STDERR            => FCGI\Record\Stderr::class,
-        FCGI::DATA              => FCGI\Record\Data::class,
-        FCGI::GET_VALUES        => FCGI\Record\GetValues::class,
-        FCGI::GET_VALUES_RESULT => FCGI\Record\GetValuesResult::class,
-        FCGI::UNKNOWN_TYPE      => FCGI\Record\UnknownType::class,
-    ];
-
     /**
      * Checks if the buffer contains a valid frame to parse
      */
@@ -46,47 +28,39 @@ class FrameParser
             return false;
         }
 
-        /** @phpstan-var false|array{version: int, type: int, requestId: int, contentLength: int, paddingLength: int} */
-        $fastInfo = unpack(FCGI::HEADER_FORMAT, $binaryBuffer);
-        if ($fastInfo === false) {
-            throw new \RuntimeException('Can not unpack data from the binary buffer');
-        }
-        if ($bufferLength < FCGI::HEADER_LEN + $fastInfo['contentLength'] + $fastInfo['paddingLength']) {
-            return false;
+        /** @var false|array{version: int, type: int, requestId: int, contentLength: int, paddingLength: int, reserved: int} $header */
+        $header = unpack(FCGI::HEADER_FORMAT, $binaryBuffer);
+        if ($header === false) {
+            throw new ProtocolException('Can not unpack the FastCGI record header');
         }
 
-        return true;
+        return $bufferLength >= FCGI::HEADER_LEN + $header['contentLength'] + $header['paddingLength'];
     }
 
     /**
-     * Parses a frame from the binary buffer
+     * Parses a frame from the binary buffer, consuming it from the buffer
      *
      * @return Record One of the corresponding FCGI record
      */
     public static function parseFrame(string &$binaryBuffer): Record
     {
-        $bufferLength = strlen($binaryBuffer);
-        if ($bufferLength < FCGI::HEADER_LEN) {
-            throw new \RuntimeException("Not enough data in the buffer to parse");
-        }
-        /** @phpstan-var false|array{version: int, type: int, requestId: int, contentLength: int, paddingLength: int} */
-        $recordHeader = unpack(FCGI::HEADER_FORMAT, $binaryBuffer);
-        if ($recordHeader === false) {
-            throw new \RuntimeException('Can not unpack data from the binary buffer');
-        }
-        $recordType = $recordHeader['type'];
-        if (!isset(self::$classMapping[$recordType])) {
-            throw new \DomainException("Invalid FCGI record type {$recordType} received");
+        if (strlen($binaryBuffer) < FCGI::HEADER_LEN) {
+            throw new ProtocolException('Not enough data in the buffer to parse');
         }
 
-        /** @var Record $className */
-        $className = self::$classMapping[$recordType];
-        $record    = $className::unpack($binaryBuffer);
+        /** @var false|array{version: int, type: int, requestId: int, contentLength: int, paddingLength: int, reserved: int} $header */
+        $header = unpack(FCGI::HEADER_FORMAT, $binaryBuffer);
+        if ($header === false) {
+            throw new ProtocolException('Can not unpack the FastCGI record header');
+        }
 
-        $offset       = FCGI::HEADER_LEN + $record->getContentLength() + $record->getPaddingLength();
-        $binaryBuffer = substr($binaryBuffer, $offset);
+        $recordType = RecordType::tryFrom($header['type'])
+            ?? throw new ProtocolException("Invalid FastCGI record type {$header['type']} received");
+
+        $record = $recordType->recordClass()::unpack($binaryBuffer);
+
+        $binaryBuffer = substr($binaryBuffer, FCGI::HEADER_LEN + $header['contentLength'] + $header['paddingLength']);
 
         return $record;
     }
-
 }

--- a/src/FCGI/FrameParser.php
+++ b/src/FCGI/FrameParser.php
@@ -28,13 +28,14 @@ final class FrameParser
             return false;
         }
 
-        /** @var false|array{version: int, type: int, requestId: int, contentLength: int, paddingLength: int, reserved: int} $header */
-        $header = unpack(FCGI::HEADER_FORMAT, $binaryBuffer);
-        if ($header === false) {
+        // Only the two length fields (bytes 4-6) are needed to decide about frame completeness
+        /** @var false|array{contentLength: int, paddingLength: int} $lengths */
+        $lengths = unpack('ncontentLength/CpaddingLength', $binaryBuffer, 4);
+        if ($lengths === false) {
             throw new ProtocolException('Can not unpack the FastCGI record header');
         }
 
-        return $bufferLength >= FCGI::HEADER_LEN + $header['contentLength'] + $header['paddingLength'];
+        return $bufferLength >= FCGI::HEADER_LEN + $lengths['contentLength'] + $lengths['paddingLength'];
     }
 
     /**

--- a/src/FCGI/ProtocolException.php
+++ b/src/FCGI/ProtocolException.php
@@ -1,0 +1,20 @@
+<?php
+/*
+ * Protocol FCGI library
+ *
+ * @copyright Copyright 2021. Lisachenko Alexander <lisachenko.it@gmail.com>
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+declare(strict_types=1);
+
+namespace Lisachenko\Protocol\FCGI;
+
+/**
+ * Thrown when binary data violates the FastCGI protocol: truncated or malformed
+ * buffers, unknown record types, or invalid enumeration values on the wire.
+ */
+class ProtocolException extends \RuntimeException
+{
+}

--- a/src/FCGI/ProtocolStatus.php
+++ b/src/FCGI/ProtocolStatus.php
@@ -1,0 +1,39 @@
+<?php
+/*
+ * Protocol FCGI library
+ *
+ * @copyright Copyright 2021. Lisachenko Alexander <lisachenko.it@gmail.com>
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+declare(strict_types=1);
+
+namespace Lisachenko\Protocol\FCGI;
+
+/**
+ * Values for the protocolStatus component of FCGI_EndRequestBody.
+ */
+enum ProtocolStatus: int
+{
+    /**
+     * Normal end of request.
+     */
+    case RequestComplete = 0;
+
+    /**
+     * Rejecting a new request: the Web server sent concurrent requests over one connection
+     * to an application that is designed to process one request at a time per connection.
+     */
+    case CantMultiplexConnection = 1;
+
+    /**
+     * Rejecting a new request: the application ran out of some resource, e.g. database connections.
+     */
+    case Overloaded = 2;
+
+    /**
+     * Rejecting a new request: the Web server specified a role that is unknown to the application.
+     */
+    case UnknownRole = 3;
+}

--- a/src/FCGI/Record.php
+++ b/src/FCGI/Record.php
@@ -13,11 +13,12 @@ namespace Lisachenko\Protocol\FCGI;
 
 use Lisachenko\Protocol\FCGI;
 use ReflectionClass;
+use Stringable;
 
 /**
  * FCGI record.
  */
-class Record
+class Record implements Stringable
 {
     /**
      * Identifies the FastCGI protocol version.
@@ -27,7 +28,7 @@ class Record
     /**
      * Identifies the FastCGI record type, i.e. the general function that the record performs.
      */
-    protected int $type = FCGI::UNKNOWN_TYPE;
+    protected RecordType $type = RecordType::UnknownType;
 
     /**
      * Identifies the FastCGI request to which the record belongs.
@@ -61,32 +62,31 @@ class Record
 
     /**
      * Unpacks the message from the binary data buffer
-     *
-     * @return static
      */
-    final public static function unpack(string $binaryData): self
+    final public static function unpack(string $binaryData): static
     {
         /** @var static $self */
-        $self   = (new ReflectionClass(static::class))->newInstanceWithoutConstructor();
+        $self = new ReflectionClass(static::class)->newInstanceWithoutConstructor();
 
-        /** @phpstan-var false|array{version: int, type: int, requestId: int, contentLength: int, paddingLength: int, reserved: int} */
-        $packet = unpack(FCGI::HEADER_FORMAT, $binaryData);
-        if ($packet === false) {
-            throw new \RuntimeException('Can not unpack data from the binary buffer');
+        /** @var false|array{version: int, type: int, requestId: int, contentLength: int, paddingLength: int, reserved: int} $header */
+        $header = unpack(FCGI::HEADER_FORMAT, $binaryData);
+        if ($header === false) {
+            throw new ProtocolException('Can not unpack the FastCGI record header');
         }
-        [
-            $self->version,
-            $self->type,
-            $self->requestId,
-            $self->contentLength,
-            $self->paddingLength,
-            $self->reserved
-        ] = array_values($packet);
 
-        $payload = substr($binaryData, FCGI::HEADER_LEN);
-        self::unpackPayload($self, $payload);
-        if (static::class !== self::class && $self->contentLength > 0) {
-            static::unpackPayload($self, $payload);
+        $self->version       = $header['version'];
+        $self->type          = RecordType::tryFrom($header['type'])
+            ?? throw new ProtocolException("Invalid FastCGI record type {$header['type']} received");
+        $self->requestId     = $header['requestId'];
+        $self->contentLength = $header['contentLength'];
+        $self->paddingLength = $header['paddingLength'];
+        $self->reserved      = $header['reserved'];
+
+        $self->contentData = substr($binaryData, FCGI::HEADER_LEN, $self->contentLength);
+        $self->paddingData = substr($binaryData, FCGI::HEADER_LEN + $self->contentLength, $self->paddingLength);
+
+        if ($self->contentLength > 0) {
+            $self->unpackPayload($self->contentData);
         }
 
         return $self;
@@ -100,7 +100,7 @@ class Record
         $headerPacket = pack(
             "CCnnCC",
             $this->version,
-            $this->type,
+            $this->type->value,
             $this->requestId,
             $this->contentLength,
             $this->paddingLength,
@@ -116,7 +116,7 @@ class Record
     /**
      * Sets the content data and adjusts the length fields
      */
-    public function setContentData(string $data): self
+    public function setContentData(string $data): static
     {
         $this->contentData   = $data;
         $this->contentLength = strlen($this->contentData);
@@ -145,7 +145,7 @@ class Record
     /**
      * Returns record type
      */
-    public function getType(): int
+    public function getType(): RecordType
     {
         return $this->type;
     }
@@ -164,7 +164,7 @@ class Record
      * There should be only one unique ID for all active requests,
      * use random number or preferably resetting auto-increment.
      */
-    public function setRequestId(int $requestId): self
+    public function setRequestId(int $requestId): static
     {
         $this->requestId = $requestId;
 
@@ -188,22 +188,13 @@ class Record
     }
 
     /**
-     * Method to unpack the payload for the record.
+     * Hydrates record-specific fields from the raw content bytes.
      *
-     * NB: Default implementation will be always called
-     * @param static $self
+     * The default implementation is a no-op: the base record exposes
+     * its raw payload via getContentData().
      */
-    protected static function unpackPayload(Record $self, string $binaryData): void
+    protected function unpackPayload(string $binaryData): void
     {
-        /** @phpstan-var false|array{contentData: string, paddingData: string} */
-        $payload = unpack("a{$self->contentLength}contentData/a{$self->paddingLength}paddingData", $binaryData);
-        if ($payload === false) {
-            throw new \RuntimeException('Can not unpack data from the binary buffer');
-        }
-        [
-            $self->contentData,
-            $self->paddingData
-        ] = array_values($payload);
     }
 
     /**

--- a/src/FCGI/Record.php
+++ b/src/FCGI/Record.php
@@ -61,12 +61,20 @@ class Record implements Stringable
     private string $paddingData = '';
 
     /**
+     * Per-class reflection cache to avoid paying the reflection cost for every parsed record.
+     *
+     * @var array<class-string<Record>, ReflectionClass<covariant Record>>
+     */
+    private static array $reflectionCache = [];
+
+    /**
      * Unpacks the message from the binary data buffer
      */
     final public static function unpack(string $binaryData): static
     {
         /** @var static $self */
-        $self = new ReflectionClass(static::class)->newInstanceWithoutConstructor();
+        $self = (self::$reflectionCache[static::class] ??= new ReflectionClass(static::class))
+            ->newInstanceWithoutConstructor();
 
         /** @var false|array{version: int, type: int, requestId: int, contentLength: int, paddingLength: int, reserved: int} $header */
         $header = unpack(FCGI::HEADER_FORMAT, $binaryData);

--- a/src/FCGI/Record/AbortRequest.php
+++ b/src/FCGI/Record/AbortRequest.php
@@ -11,17 +11,17 @@ declare(strict_types=1);
 
 namespace Lisachenko\Protocol\FCGI\Record;
 
-use Lisachenko\Protocol\FCGI;
 use Lisachenko\Protocol\FCGI\Record;
+use Lisachenko\Protocol\FCGI\RecordType;
 
 /**
  * The Web server sends a FCGI_ABORT_REQUEST record to abort a request
  */
-class AbortRequest extends Record
+final class AbortRequest extends Record
 {
     public function __construct(int $requestId)
     {
-        $this->type = FCGI::ABORT_REQUEST;
+        $this->type = RecordType::AbortRequest;
         $this->setRequestId($requestId);
     }
 }

--- a/src/FCGI/Record/BeginRequest.php
+++ b/src/FCGI/Record/BeginRequest.php
@@ -11,57 +11,34 @@ declare(strict_types=1);
 
 namespace Lisachenko\Protocol\FCGI\Record;
 
-use Lisachenko\Protocol\FCGI;
+use Lisachenko\Protocol\FCGI\ProtocolException;
 use Lisachenko\Protocol\FCGI\Record;
+use Lisachenko\Protocol\FCGI\RecordType;
+use Lisachenko\Protocol\FCGI\Role;
 
 /**
  * The Web server sends a FCGI_BEGIN_REQUEST record to start a request.
  */
-class BeginRequest extends Record
+final class BeginRequest extends Record
 {
     /**
-     * The role component sets the role the Web server expects the application to play.
-     * The currently-defined roles are:
-     *   FCGI_RESPONDER
-     *   FCGI_AUTHORIZER
-     *   FCGI_FILTER
+     * @param Role   $role      The role the Web server expects the application to play
+     * @param int    $flags     Bit mask controlling connection shutdown, see FCGI::KEEP_CONN
+     * @param string $reserved1 Reserved data, 5 bytes maximum
      */
-    protected int $role = FCGI::UNKNOWN_ROLE;
-
-    /**
-     * The flags component contains a bit that controls connection shutdown.
-     *
-     * flags & FCGI_KEEP_CONN:
-     *   If zero, the application closes the connection after responding to this request.
-     *   If not zero, the application does not close the connection after responding to this request;
-     *   the Web server retains responsibility for the connection.
-     */
-    protected int $flags;
-
-    /**
-     * Reserved data, 5 bytes maximum
-     */
-    protected string $reserved1;
-
-    public function __construct(int $role = FCGI::UNKNOWN_ROLE, int $flags = 0, string $reserved = '')
-    {
-        $this->type      = FCGI::BEGIN_REQUEST;
-        $this->role      = $role;
-        $this->flags     = $flags;
-        $this->reserved1 = $reserved;
+    public function __construct(
+        protected Role $role,
+        protected int $flags = 0,
+        protected string $reserved1 = '',
+    ) {
+        $this->type = RecordType::BeginRequest;
         $this->setContentData($this->packPayload());
     }
 
     /**
-     * Returns the role
-     *
-     * The role component sets the role the Web server expects the application to play.
-     * The currently-defined roles are:
-     *   FCGI_RESPONDER
-     *   FCGI_AUTHORIZER
-     *   FCGI_FILTER
+     * Returns the role the Web server expects the application to play
      */
-    public function getRole(): int
+    public function getRole(): Role
     {
         return $this->role;
     }
@@ -81,31 +58,25 @@ class BeginRequest extends Record
         return $this->flags;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected static function unpackPayload($self, string $binaryData): void
+    protected function unpackPayload(string $binaryData): void
     {
-        /** @phpstan-var false|array{role: int, flags: int, reserved: string} */
+        /** @var false|array{role: int, flags: int, reserved: string} $payload */
         $payload = unpack("nrole/Cflags/a5reserved", $binaryData);
         if ($payload === false) {
-            throw new \RuntimeException('Can not unpack data from the binary buffer');
+            throw new ProtocolException('Can not unpack the FCGI_BeginRequestBody');
         }
-        [
-            $self->role,
-            $self->flags,
-            $self->reserved1
-        ] = array_values($payload);
+
+        $this->role      = Role::tryFrom($payload['role'])
+            ?? throw new ProtocolException("Invalid FastCGI role {$payload['role']} received");
+        $this->flags     = $payload['flags'];
+        $this->reserved1 = $payload['reserved'];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function packPayload(): string
     {
         return pack(
             "nCa5",
-            $this->role,
+            $this->role->value,
             $this->flags,
             $this->reserved1
         );

--- a/src/FCGI/Record/Data.php
+++ b/src/FCGI/Record/Data.php
@@ -11,19 +11,19 @@ declare(strict_types=1);
 
 namespace Lisachenko\Protocol\FCGI\Record;
 
-use Lisachenko\Protocol\FCGI;
 use Lisachenko\Protocol\FCGI\Record;
+use Lisachenko\Protocol\FCGI\RecordType;
 
 /**
  * Data binary stream
  *
  * FCGI_DATA is a second stream record type used to send additional data to the application.
  */
-class Data extends Record
+final class Data extends Record
 {
     public function __construct(string $contentData)
     {
-        $this->type = FCGI::DATA;
+        $this->type = RecordType::Data;
         $this->setContentData($contentData);
     }
 }

--- a/src/FCGI/Record/EndRequest.php
+++ b/src/FCGI/Record/EndRequest.php
@@ -11,46 +11,28 @@ declare(strict_types=1);
 
 namespace Lisachenko\Protocol\FCGI\Record;
 
-use Lisachenko\Protocol\FCGI;
+use Lisachenko\Protocol\FCGI\ProtocolException;
+use Lisachenko\Protocol\FCGI\ProtocolStatus;
 use Lisachenko\Protocol\FCGI\Record;
+use Lisachenko\Protocol\FCGI\RecordType;
 
 /**
  * The application sends a FCGI_END_REQUEST record to terminate a request, either because the application
  * has processed the request or because the application has rejected the request.
  */
-class EndRequest extends Record
+final class EndRequest extends Record
 {
     /**
-     * The appStatus component is an application-level status code. Each role documents its usage of appStatus.
+     * @param ProtocolStatus $protocolStatus The protocol-level status code
+     * @param int            $appStatus      The application-level status code, each role documents its usage
+     * @param string         $reserved1      Reserved data, 3 bytes maximum
      */
-    protected int $appStatus = 0;
-
-    /**
-     * The protocolStatus component is a protocol-level status code.
-     *
-     * The possible protocolStatus values are:
-     *   FCGI_REQUEST_COMPLETE: normal end of request.
-     *   FCGI_CANT_MPX_CONN: rejecting a new request.
-     *      This happens when a Web server sends concurrent requests over one connection to an application that is
-     *      designed to process one request at a time per connection.
-     *   FCGI_OVERLOADED: rejecting a new request.
-     *      This happens when the application runs out of some resource, e.g. database connections.
-     *   FCGI_UNKNOWN_ROLE: rejecting a new request.
-     *      This happens when the Web server has specified a role that is unknown to the application.
-     */
-    protected int $protocolStatus = FCGI::REQUEST_COMPLETE;
-
-    /**
-     * Reserved data, 3 bytes maximum
-     */
-    protected string $reserved1;
-
-    public function __construct(int $protocolStatus = FCGI::REQUEST_COMPLETE, int $appStatus = 0, string $reserved = '')
-    {
-        $this->type           = FCGI::END_REQUEST;
-        $this->protocolStatus = $protocolStatus;
-        $this->appStatus      = $appStatus;
-        $this->reserved1      = $reserved;
+    public function __construct(
+        protected ProtocolStatus $protocolStatus = ProtocolStatus::RequestComplete,
+        protected int $appStatus = 0,
+        protected string $reserved1 = '',
+    ) {
+        $this->type = RecordType::EndRequest;
         $this->setContentData($this->packPayload());
     }
 
@@ -65,49 +47,33 @@ class EndRequest extends Record
     }
 
     /**
-     * Returns the protocol status
-     *
-     * The possible protocolStatus values are:
-     *   FCGI_REQUEST_COMPLETE: normal end of request.
-     *   FCGI_CANT_MPX_CONN: rejecting a new request.
-     *      This happens when a Web server sends concurrent requests over one connection to an application that is
-     *      designed to process one request at a time per connection.
-     *   FCGI_OVERLOADED: rejecting a new request.
-     *      This happens when the application runs out of some resource, e.g. database connections.
-     *   FCGI_UNKNOWN_ROLE: rejecting a new request.
-     *      This happens when the Web server has specified a role that is unknown to the application.
+     * Returns the protocol-level status code
      */
-    public function getProtocolStatus(): int
+    public function getProtocolStatus(): ProtocolStatus
     {
         return $this->protocolStatus;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected static function unpackPayload($self, string $binaryData): void
+    protected function unpackPayload(string $binaryData): void
     {
-        /** @phpstan-var false|array{appStatus: int, protocolStatus: int, reserved: string} */
+        /** @var false|array{appStatus: int, protocolStatus: int, reserved: string} $payload */
         $payload = unpack("NappStatus/CprotocolStatus/a3reserved", $binaryData);
         if ($payload === false) {
-            throw new \RuntimeException('Can not unpack data from the binary buffer');
+            throw new ProtocolException('Can not unpack the FCGI_EndRequestBody');
         }
-        [
-            $self->appStatus,
-            $self->protocolStatus,
-            $self->reserved1
-        ] = array_values($payload);
+
+        $this->appStatus      = $payload['appStatus'];
+        $this->protocolStatus = ProtocolStatus::tryFrom($payload['protocolStatus'])
+            ?? throw new ProtocolException("Invalid FastCGI protocol status {$payload['protocolStatus']} received");
+        $this->reserved1      = $payload['reserved'];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function packPayload(): string
     {
         return pack(
             "NCa3",
             $this->appStatus,
-            $this->protocolStatus,
+            $this->protocolStatus->value,
             $this->reserved1
         );
     }

--- a/src/FCGI/Record/GetValues.php
+++ b/src/FCGI/Record/GetValues.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace Lisachenko\Protocol\FCGI\Record;
 
-use Lisachenko\Protocol\FCGI;
+use Lisachenko\Protocol\FCGI\RecordType;
 
 /**
  * GetValues API
@@ -33,18 +33,16 @@ use Lisachenko\Protocol\FCGI;
  *   FCGI_MPXS_CONNS: "0" if this application does not multiplex connections (i.e. handle concurrent requests
  *                    over each connection), "1" otherwise.
  */
-class GetValues extends Params
+final class GetValues extends Params
 {
     /**
      * Constructs a request
      *
-     * @param array                $keys List of keys to receive
-     *
-     * @phpstan-param list<string> $keys
+     * @param list<string> $keys List of keys to receive
      */
     public function __construct(array $keys)
     {
         parent::__construct(array_fill_keys($keys, ''));
-        $this->type = FCGI::GET_VALUES;
+        $this->type = RecordType::GetValues;
     }
 }

--- a/src/FCGI/Record/GetValuesResult.php
+++ b/src/FCGI/Record/GetValuesResult.php
@@ -11,38 +11,26 @@ declare(strict_types=1);
 
 namespace Lisachenko\Protocol\FCGI\Record;
 
-use Lisachenko\Protocol\FCGI;
+use Lisachenko\Protocol\FCGI\RecordType;
 
 /**
  * GetValues API
  *
- * The Web server can query specific variables within the application.
- * The server will typically perform a query on application startup in order to to automate certain aspects of
- * system configuration.
- *
- * The application responds by sending a record {FCGI_GET_VALUES_RESULT, 0, ...} with the values supplied.
+ * The application responds to a FCGI_GET_VALUES management record by sending a record
+ * {FCGI_GET_VALUES_RESULT, 0, ...} with the values supplied.
  * If the application doesn't understand a variable name that was included in the query, it omits that name from
  * the response.
- *
- * FCGI_GET_VALUES is designed to allow an open-ended set of variables.
- *
- * The initial set provides information to help the server perform application and connection management:
- *   FCGI_MAX_CONNS:  The maximum number of concurrent transport connections this application will accept,
- *                    e.g. "1" or "10".
- *   FCGI_MAX_REQS:   The maximum number of concurrent requests this application will accept, e.g. "1" or "50".
- *   FCGI_MPXS_CONNS: "0" if this application does not multiplex connections (i.e. handle concurrent requests
- *                    over each connection), "1" otherwise.
  */
-class GetValuesResult extends Params
+final class GetValuesResult extends Params
 {
     /**
      * Constructs a param request
      *
-     * @phpstan-param array<string, string> $values
+     * @param array<string, string> $values
      */
     public function __construct(array $values)
     {
         parent::__construct($values);
-        $this->type = FCGI::GET_VALUES_RESULT;
+        $this->type = RecordType::GetValuesResult;
     }
 }

--- a/src/FCGI/Record/Params.php
+++ b/src/FCGI/Record/Params.php
@@ -55,52 +55,46 @@ class Params extends Record
 
     protected function unpackPayload(string $binaryData): void
     {
-        $currentOffset = 0;
-        do {
-            /** @var false|array{nameLengthHigh: int} $payload */
-            $payload = unpack('CnameLengthHigh', $binaryData);
-            if ($payload === false) {
-                throw new ProtocolException('Can not unpack the FCGI_NameValuePair');
-            }
-            $isLongName  = ($payload['nameLengthHigh'] >> 7 == 1);
-            $valueOffset = $isLongName ? 4 : 1;
+        $payloadLength = strlen($binaryData);
+        $offset        = 0;
+        while ($offset < $payloadLength) {
+            [$nameLength, $offset]  = self::unpackLength($binaryData, $offset);
+            [$valueLength, $offset] = self::unpackLength($binaryData, $offset);
 
-            /** @var false|array{valueLengthHigh: int} $payload */
-            $payload = unpack('CvalueLengthHigh', substr($binaryData, $valueOffset));
-            if ($payload === false) {
-                throw new ProtocolException('Can not unpack the FCGI_NameValuePair');
-            }
-            $isLongValue = ($payload['valueLengthHigh'] >> 7 == 1);
-            $dataOffset  = $valueOffset + ($isLongValue ? 4 : 1);
+            $name   = substr($binaryData, $offset, $nameLength);
+            $value  = substr($binaryData, $offset + $nameLength, $valueLength);
+            $offset += $nameLength + $valueLength;
 
-            $format = ($isLongName ? 'NnameLength' : 'CnameLength')
-                . '/' . ($isLongValue ? 'NvalueLength' : 'CvalueLength');
+            $this->values[$name] = $value;
+        }
+    }
 
-            /** @var false|array{nameLength: int, valueLength: int} $payload */
-            $payload = unpack($format, $binaryData);
-            if ($payload === false) {
-                throw new ProtocolException('Can not unpack the FCGI_NameValuePair');
-            }
+    /**
+     * Reads one FCGI_NameValuePair length field at the given offset.
+     *
+     * Lengths below 128 are encoded in a single byte; longer ones use four bytes
+     * with the top bit set.
+     *
+     * @return array{int, int} The decoded length and the offset right after it
+     */
+    private static function unpackLength(string $binaryData, int $offset): array
+    {
+        if (!isset($binaryData[$offset])) {
+            throw new ProtocolException('Can not unpack the FCGI_NameValuePair');
+        }
 
-            // Clear top bit for long record
-            $nameLength  = $payload['nameLength'] & ($isLongName ? 0x7fffffff : 0x7f);
-            $valueLength = $payload['valueLength'] & ($isLongValue ? 0x7fffffff : 0x7f);
+        $firstByte = ord($binaryData[$offset]);
+        if ($firstByte >> 7 === 0) {
+            return [$firstByte, $offset + 1];
+        }
 
-            /** @var false|array{nameData: string, valueData: string} $payload */
-            $payload = unpack(
-                "a{$nameLength}nameData/a{$valueLength}valueData",
-                substr($binaryData, $dataOffset)
-            );
-            if ($payload === false) {
-                throw new ProtocolException('Can not unpack the FCGI_NameValuePair');
-            }
+        /** @var false|array{length: int} $payload */
+        $payload = unpack('Nlength', $binaryData, $offset);
+        if ($payload === false) {
+            throw new ProtocolException('Can not unpack the FCGI_NameValuePair');
+        }
 
-            $this->values[$payload['nameData']] = $payload['valueData'];
-
-            $keyValueLength = $dataOffset + $nameLength + $valueLength;
-            $binaryData     = substr($binaryData, $keyValueLength);
-            $currentOffset += $keyValueLength;
-        } while ($currentOffset < $this->getContentLength());
+        return [$payload['length'] & 0x7fffffff, $offset + 4];
     }
 
     protected function packPayload(): string

--- a/src/FCGI/Record/Params.php
+++ b/src/FCGI/Record/Params.php
@@ -11,8 +11,9 @@ declare(strict_types=1);
 
 namespace Lisachenko\Protocol\FCGI\Record;
 
-use Lisachenko\Protocol\FCGI;
+use Lisachenko\Protocol\FCGI\ProtocolException;
 use Lisachenko\Protocol\FCGI\Record;
+use Lisachenko\Protocol\FCGI\RecordType;
 
 /**
  * Params request record
@@ -22,19 +23,22 @@ class Params extends Record
     /**
      * List of params
      *
-     * @var string[]
-     * @phpstan-var array<string, string>
+     * NB: this property intentionally keeps its default value instead of being promoted
+     * to the constructor: an empty FCGI_PARAMS record (the end-of-stream marker) is
+     * hydrated from the wire without running the constructor or unpackPayload().
+     *
+     * @var array<string, string>
      */
     protected array $values = [];
 
     /**
      * Constructs a param request
      *
-     * @phpstan-param array<string, string> $values
+     * @param array<string, string> $values
      */
     public function __construct(array $values)
     {
-        $this->type   = FCGI::PARAMS;
+        $this->type   = RecordType::Params;
         $this->values = $values;
         $this->setContentData($this->packPayload());
     }
@@ -42,92 +46,75 @@ class Params extends Record
     /**
      * Returns an associative list of parameters
      *
-     * @phpstan-return array<string, string>
+     * @return array<string, string>
      */
     public function getValues(): array
     {
         return $this->values;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected static function unpackPayload($self, string $binaryData): void
+    protected function unpackPayload(string $binaryData): void
     {
         $currentOffset = 0;
         do {
-            /** @phpstan-var false|array{nameLengthHigh: int} */
+            /** @var false|array{nameLengthHigh: int} $payload */
             $payload = unpack('CnameLengthHigh', $binaryData);
             if ($payload === false) {
-                throw new \RuntimeException('Can not unpack data from the binary buffer');
+                throw new ProtocolException('Can not unpack the FCGI_NameValuePair');
             }
-            [$nameLengthHigh] = array_values($payload);
-            $isLongName  = ($nameLengthHigh >> 7 == 1);
+            $isLongName  = ($payload['nameLengthHigh'] >> 7 == 1);
             $valueOffset = $isLongName ? 4 : 1;
 
-            /** @phpstan-var false|array{valueLengthHigh: int} */
+            /** @var false|array{valueLengthHigh: int} $payload */
             $payload = unpack('CvalueLengthHigh', substr($binaryData, $valueOffset));
             if ($payload === false) {
-                throw new \RuntimeException('Can not unpack data from the binary buffer');
+                throw new ProtocolException('Can not unpack the FCGI_NameValuePair');
             }
-            [$valueLengthHigh] = array_values($payload);
-            $isLongValue = ($valueLengthHigh >> 7 == 1);
+            $isLongValue = ($payload['valueLengthHigh'] >> 7 == 1);
             $dataOffset  = $valueOffset + ($isLongValue ? 4 : 1);
 
-            $formatParts = [
-                $isLongName ? 'NnameLength' : 'CnameLength',
-                $isLongValue ? 'NvalueLength' : 'CvalueLength',
-            ];
-            $format      = join('/', $formatParts);
+            $format = ($isLongName ? 'NnameLength' : 'CnameLength')
+                . '/' . ($isLongValue ? 'NvalueLength' : 'CvalueLength');
 
-            /** @phpstan-var false|array{nameLength: int, valueLength: int} */
+            /** @var false|array{nameLength: int, valueLength: int} $payload */
             $payload = unpack($format, $binaryData);
             if ($payload === false) {
-                throw new \RuntimeException('Can not unpack data from the binary buffer');
+                throw new ProtocolException('Can not unpack the FCGI_NameValuePair');
             }
-            [$nameLength, $valueLength] = array_values($payload);
 
             // Clear top bit for long record
-            $nameLength  &= ($isLongName ? 0x7fffffff : 0x7f);
-            $valueLength &= ($isLongValue ? 0x7fffffff : 0x7f);
+            $nameLength  = $payload['nameLength'] & ($isLongName ? 0x7fffffff : 0x7f);
+            $valueLength = $payload['valueLength'] & ($isLongValue ? 0x7fffffff : 0x7f);
 
-            /** @phpstan-var false|array{nameData: string, valueData: string} */
+            /** @var false|array{nameData: string, valueData: string} $payload */
             $payload = unpack(
                 "a{$nameLength}nameData/a{$valueLength}valueData",
                 substr($binaryData, $dataOffset)
             );
             if ($payload === false) {
-                throw new \RuntimeException('Can not unpack data from the binary buffer');
+                throw new ProtocolException('Can not unpack the FCGI_NameValuePair');
             }
-            [$nameData, $valueData] = array_values($payload);
 
-            $self->values[$nameData] = $valueData;
+            $this->values[$payload['nameData']] = $payload['valueData'];
 
             $keyValueLength = $dataOffset + $nameLength + $valueLength;
             $binaryData     = substr($binaryData, $keyValueLength);
-            $currentOffset  += $keyValueLength;
-        } while ($currentOffset < $self->getContentLength());
+            $currentOffset += $keyValueLength;
+        } while ($currentOffset < $this->getContentLength());
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function packPayload(): string
     {
         $payload = '';
         foreach ($this->values as $nameData => $valueData) {
             $nameLength  = strlen($nameData);
-            $valueLength = strlen((string)$valueData);
+            $valueLength = strlen($valueData);
             $isLongName  = $nameLength > 127;
             $isLongValue = $valueLength > 127;
-            $formatParts = [
-                $isLongName ? 'N' : 'C',
-                $isLongValue ? 'N' : 'C',
-                "a{$nameLength}",
-                "a{$valueLength}",
-            ];
 
-            $format = join('', $formatParts);
+            $format = ($isLongName ? 'N' : 'C')
+                . ($isLongValue ? 'N' : 'C')
+                . "a{$nameLength}a{$valueLength}";
 
             $payload .= pack(
                 $format,

--- a/src/FCGI/Record/Stderr.php
+++ b/src/FCGI/Record/Stderr.php
@@ -11,19 +11,19 @@ declare(strict_types=1);
 
 namespace Lisachenko\Protocol\FCGI\Record;
 
-use Lisachenko\Protocol\FCGI;
 use Lisachenko\Protocol\FCGI\Record;
+use Lisachenko\Protocol\FCGI\RecordType;
 
 /**
  * Stderr binary stream
  *
  * FCGI_STDERR is a stream record for sending arbitrary data from the application to the Web server
  */
-class Stderr extends Record
+final class Stderr extends Record
 {
     public function __construct(string $contentData)
     {
-        $this->type = FCGI::STDERR;
+        $this->type = RecordType::Stderr;
         $this->setContentData($contentData);
     }
 }

--- a/src/FCGI/Record/Stdin.php
+++ b/src/FCGI/Record/Stdin.php
@@ -11,19 +11,19 @@ declare(strict_types=1);
 
 namespace Lisachenko\Protocol\FCGI\Record;
 
-use Lisachenko\Protocol\FCGI;
 use Lisachenko\Protocol\FCGI\Record;
+use Lisachenko\Protocol\FCGI\RecordType;
 
 /**
  * Stdin binary stream
  *
  * FCGI_STDIN is a stream record type used in sending arbitrary data from the Web server to the application
  */
-class Stdin extends Record
+final class Stdin extends Record
 {
     public function __construct(string $contentData)
     {
-        $this->type = FCGI::STDIN;
+        $this->type = RecordType::Stdin;
         $this->setContentData($contentData);
     }
 }

--- a/src/FCGI/Record/Stdout.php
+++ b/src/FCGI/Record/Stdout.php
@@ -11,19 +11,19 @@ declare(strict_types=1);
 
 namespace Lisachenko\Protocol\FCGI\Record;
 
-use Lisachenko\Protocol\FCGI;
 use Lisachenko\Protocol\FCGI\Record;
+use Lisachenko\Protocol\FCGI\RecordType;
 
 /**
  * Stdout binary stream
  *
  * FCGI_STDOUT is a stream record for sending arbitrary data from the application to the Web server
  */
-class Stdout extends Record
+final class Stdout extends Record
 {
     public function __construct(string $contentData)
     {
-        $this->type = FCGI::STDOUT;
+        $this->type = RecordType::Stdout;
         $this->setContentData($contentData);
     }
 }

--- a/src/FCGI/Record/UnknownType.php
+++ b/src/FCGI/Record/UnknownType.php
@@ -11,8 +11,9 @@ declare(strict_types=1);
 
 namespace Lisachenko\Protocol\FCGI\Record;
 
-use Lisachenko\Protocol\FCGI;
+use Lisachenko\Protocol\FCGI\ProtocolException;
 use Lisachenko\Protocol\FCGI\Record;
+use Lisachenko\Protocol\FCGI\RecordType;
 
 /**
  * Record for unknown queries
@@ -22,23 +23,17 @@ use Lisachenko\Protocol\FCGI\Record;
  * When an application receives a management record whose type T it does not understand, the application responds
  * with {FCGI_UNKNOWN_TYPE, 0, {T}}.
  */
-class UnknownType extends Record
+final class UnknownType extends Record
 {
     /**
-     * Type of the unrecognized management record.
+     * @param int    $unrecognizedType Type of the unrecognized management record
+     * @param string $reserved1        Reserved data, 7 bytes maximum
      */
-    protected int $type1;
-
-    /**
-     * Reserved data, 7 bytes maximum
-     */
-    protected string $reserved1;
-
-    public function __construct(int $type, string $reserved = '')
-    {
-        $this->type      = FCGI::UNKNOWN_TYPE;
-        $this->type1     = $type;
-        $this->reserved1 = $reserved;
+    public function __construct(
+        protected int $unrecognizedType,
+        protected string $reserved1 = '',
+    ) {
+        $this->type = RecordType::UnknownType;
         $this->setContentData($this->packPayload());
     }
 
@@ -47,30 +42,26 @@ class UnknownType extends Record
      */
     public function getUnrecognizedType(): int
     {
-        return $this->type1;
+        return $this->unrecognizedType;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public static function unpackPayload($self, string $binaryData): void
+    protected function unpackPayload(string $binaryData): void
     {
-        /** @phpstan-var false|array{type: int, reserved: string} */
+        /** @var false|array{type: int, reserved: string} $payload */
         $payload = unpack("Ctype/a7reserved", $binaryData);
         if ($payload === false) {
-            throw new \RuntimeException('Can not unpack data from the binary buffer');
+            throw new ProtocolException('Can not unpack the FCGI_UnknownTypeBody');
         }
-        [$self->type1, $self->reserved1] = array_values($payload);
+
+        $this->unrecognizedType = $payload['type'];
+        $this->reserved1        = $payload['reserved'];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function packPayload(): string
     {
         return pack(
             "Ca7",
-            $this->type1,
+            $this->unrecognizedType,
             $this->reserved1
         );
     }

--- a/src/FCGI/RecordType.php
+++ b/src/FCGI/RecordType.php
@@ -1,0 +1,52 @@
+<?php
+/*
+ * Protocol FCGI library
+ *
+ * @copyright Copyright 2021. Lisachenko Alexander <lisachenko.it@gmail.com>
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+declare(strict_types=1);
+
+namespace Lisachenko\Protocol\FCGI;
+
+/**
+ * Values for the type component of FCGI_Header.
+ */
+enum RecordType: int
+{
+    case BeginRequest = 1;
+    case AbortRequest = 2;
+    case EndRequest = 3;
+    case Params = 4;
+    case Stdin = 5;
+    case Stdout = 6;
+    case Stderr = 7;
+    case Data = 8;
+    case GetValues = 9;
+    case GetValuesResult = 10;
+    case UnknownType = 11;
+
+    /**
+     * Returns the record class implementing this record type.
+     *
+     * @return class-string<Record>
+     */
+    public function recordClass(): string
+    {
+        return match ($this) {
+            self::BeginRequest    => Record\BeginRequest::class,
+            self::AbortRequest    => Record\AbortRequest::class,
+            self::EndRequest      => Record\EndRequest::class,
+            self::Params          => Record\Params::class,
+            self::Stdin           => Record\Stdin::class,
+            self::Stdout          => Record\Stdout::class,
+            self::Stderr          => Record\Stderr::class,
+            self::Data            => Record\Data::class,
+            self::GetValues       => Record\GetValues::class,
+            self::GetValuesResult => Record\GetValuesResult::class,
+            self::UnknownType     => Record\UnknownType::class,
+        };
+    }
+}

--- a/src/FCGI/Role.php
+++ b/src/FCGI/Role.php
@@ -1,0 +1,33 @@
+<?php
+/*
+ * Protocol FCGI library
+ *
+ * @copyright Copyright 2021. Lisachenko Alexander <lisachenko.it@gmail.com>
+ * This source file is subject to the license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+declare(strict_types=1);
+
+namespace Lisachenko\Protocol\FCGI;
+
+/**
+ * Values for the role component of FCGI_BeginRequestBody.
+ */
+enum Role: int
+{
+    /**
+     * Emulates the functionality of a CGI program: receives the request and produces the response.
+     */
+    case Responder = 1;
+
+    /**
+     * Makes an authorization decision for the request.
+     */
+    case Authorizer = 2;
+
+    /**
+     * Filters the extra data stream (FCGI_DATA) before it is returned to the Web server.
+     */
+    case Filter = 3;
+}

--- a/tests/FCGI/FrameParserTest.php
+++ b/tests/FCGI/FrameParserTest.php
@@ -54,4 +54,22 @@ class FrameParserTest extends TestCase
 
         $this->assertEquals(0, strlen($dataStream));
     }
+
+    public function testParseFrameRejectsInvalidRecordType(): void
+    {
+        /** @var string $binaryData */
+        $binaryData = hex2bin('010c000100000000'); // type 12 is not defined by the protocol
+        $this->expectException(ProtocolException::class);
+        $this->expectExceptionMessage('Invalid FastCGI record type 12 received');
+        FrameParser::parseFrame($binaryData);
+    }
+
+    public function testParseFrameRejectsTruncatedBuffer(): void
+    {
+        /** @var string $binaryData */
+        $binaryData = hex2bin('0101');
+        $this->expectException(ProtocolException::class);
+        $this->expectExceptionMessage('Not enough data in the buffer to parse');
+        FrameParser::parseFrame($binaryData);
+    }
 }

--- a/tests/FCGI/Record/AbortRequestTest.php
+++ b/tests/FCGI/Record/AbortRequestTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace Lisachenko\Protocol\FCGI\Record;
 
 use PHPUnit\Framework\TestCase;
-use Lisachenko\Protocol\FCGI;
+use Lisachenko\Protocol\FCGI\RecordType;
 
 class AbortRequestTest extends TestCase
 {
@@ -21,7 +21,7 @@ class AbortRequestTest extends TestCase
     public function testPacking(): void
     {
         $request = new AbortRequest(1);
-        $this->assertEquals(FCGI::ABORT_REQUEST, $request->getType());
+        $this->assertSame(RecordType::AbortRequest, $request->getType());
         $this->assertEquals(1, $request->getRequestId());
 
         $this->assertSame(self::$rawMessage, bin2hex((string) $request));
@@ -32,7 +32,7 @@ class AbortRequestTest extends TestCase
         /** @var string $binaryData */
         $binaryData = hex2bin(self::$rawMessage);
         $request    = AbortRequest::unpack($binaryData);
-        $this->assertEquals(FCGI::ABORT_REQUEST, $request->getType());
+        $this->assertSame(RecordType::AbortRequest, $request->getType());
         $this->assertEquals(1, $request->getRequestId());
     }
 }

--- a/tests/FCGI/Record/BeginRequestTest.php
+++ b/tests/FCGI/Record/BeginRequestTest.php
@@ -13,6 +13,8 @@ namespace Lisachenko\Protocol\FCGI\Record;
 
 use PHPUnit\Framework\TestCase;
 use Lisachenko\Protocol\FCGI;
+use Lisachenko\Protocol\FCGI\RecordType;
+use Lisachenko\Protocol\FCGI\Role;
 
 class BeginRequestTest extends TestCase
 {
@@ -20,9 +22,9 @@ class BeginRequestTest extends TestCase
 
     public function testPacking(): void
     {
-        $request = new BeginRequest(FCGI::RESPONDER, FCGI::KEEP_CONN);
-        $this->assertEquals(FCGI::BEGIN_REQUEST, $request->getType());
-        $this->assertEquals(FCGI::RESPONDER, $request->getRole());
+        $request = new BeginRequest(Role::Responder, FCGI::KEEP_CONN);
+        $this->assertSame(RecordType::BeginRequest, $request->getType());
+        $this->assertSame(Role::Responder, $request->getRole());
         $this->assertEquals(FCGI::KEEP_CONN, $request->getFlags());
 
         $this->assertSame(self::$rawMessage, bin2hex((string) $request));
@@ -34,8 +36,8 @@ class BeginRequestTest extends TestCase
         $binaryData = hex2bin(self::$rawMessage);
         $request    = BeginRequest::unpack($binaryData);
 
-        $this->assertEquals(FCGI::BEGIN_REQUEST, $request->getType());
-        $this->assertEquals(FCGI::RESPONDER, $request->getRole());
+        $this->assertSame(RecordType::BeginRequest, $request->getType());
+        $this->assertSame(Role::Responder, $request->getRole());
         $this->assertEquals(FCGI::KEEP_CONN, $request->getFlags());
     }
 }

--- a/tests/FCGI/Record/DataTest.php
+++ b/tests/FCGI/Record/DataTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace Lisachenko\Protocol\FCGI\Record;
 
 use PHPUnit\Framework\TestCase;
-use Lisachenko\Protocol\FCGI;
+use Lisachenko\Protocol\FCGI\RecordType;
 
 class DataTest extends TestCase
 {
@@ -22,7 +22,7 @@ class DataTest extends TestCase
     {
         $request = new Data('test');
         $this->assertEquals('test', $request->getContentData());
-        $this->assertEquals(FCGI::DATA, $request->getType());
+        $this->assertSame(RecordType::Data, $request->getType());
         $this->assertSame(self::$rawMessage, bin2hex((string) $request));
     }
 
@@ -31,7 +31,7 @@ class DataTest extends TestCase
         /** @var string $binaryData */
         $binaryData = hex2bin(self::$rawMessage);
         $request    = Data::unpack($binaryData);
-        $this->assertEquals(FCGI::DATA, $request->getType());
+        $this->assertSame(RecordType::Data, $request->getType());
         $this->assertEquals('test', $request->getContentData());
     }
 }

--- a/tests/FCGI/Record/EndRequestTest.php
+++ b/tests/FCGI/Record/EndRequestTest.php
@@ -12,7 +12,8 @@ declare(strict_types=1);
 namespace Lisachenko\Protocol\FCGI\Record;
 
 use PHPUnit\Framework\TestCase;
-use Lisachenko\Protocol\FCGI;
+use Lisachenko\Protocol\FCGI\ProtocolStatus;
+use Lisachenko\Protocol\FCGI\RecordType;
 
 class EndRequestTest extends TestCase
 {
@@ -20,9 +21,9 @@ class EndRequestTest extends TestCase
 
     public function testPacking(): void
     {
-        $request = new EndRequest(FCGI::REQUEST_COMPLETE, 100);
-        $this->assertEquals(FCGI::END_REQUEST, $request->getType());
-        $this->assertEquals(FCGI::REQUEST_COMPLETE, $request->getProtocolStatus());
+        $request = new EndRequest(ProtocolStatus::RequestComplete, 100);
+        $this->assertSame(RecordType::EndRequest, $request->getType());
+        $this->assertSame(ProtocolStatus::RequestComplete, $request->getProtocolStatus());
         $this->assertEquals(100, $request->getAppStatus());
 
         $this->assertSame(self::$rawMessage, bin2hex((string) $request));
@@ -34,8 +35,8 @@ class EndRequestTest extends TestCase
         $binaryData = hex2bin(self::$rawMessage);
         $request    = EndRequest::unpack($binaryData);
 
-        $this->assertEquals(FCGI::END_REQUEST, $request->getType());
-        $this->assertEquals(FCGI::REQUEST_COMPLETE, $request->getProtocolStatus());
+        $this->assertSame(RecordType::EndRequest, $request->getType());
+        $this->assertSame(ProtocolStatus::RequestComplete, $request->getProtocolStatus());
         $this->assertEquals(100, $request->getAppStatus());
     }
 }

--- a/tests/FCGI/Record/GetValuesResultTest.php
+++ b/tests/FCGI/Record/GetValuesResultTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace Lisachenko\Protocol\FCGI\Record;
 
 use PHPUnit\Framework\TestCase;
-use Lisachenko\Protocol\FCGI;
+use Lisachenko\Protocol\FCGI\RecordType;
 
 class GetValuesResultTest extends TestCase
 {
@@ -21,7 +21,7 @@ class GetValuesResultTest extends TestCase
     public function testPacking(): void
     {
         $request = new GetValuesResult(['FCGI_MPXS_CONNS' => '1']);
-        $this->assertEquals(FCGI::GET_VALUES_RESULT, $request->getType());
+        $this->assertSame(RecordType::GetValuesResult, $request->getType());
         $this->assertEquals(['FCGI_MPXS_CONNS' => '1'], $request->getValues());
 
         $this->assertSame(self::$rawMessage, bin2hex((string) $request));
@@ -33,7 +33,7 @@ class GetValuesResultTest extends TestCase
         $binaryData = hex2bin(self::$rawMessage);
         $request    = GetValuesResult::unpack($binaryData);
 
-        $this->assertEquals(FCGI::GET_VALUES_RESULT, $request->getType());
+        $this->assertSame(RecordType::GetValuesResult, $request->getType());
         $this->assertEquals(['FCGI_MPXS_CONNS' => '1'], $request->getValues());
     }
 }

--- a/tests/FCGI/Record/GetValuesTest.php
+++ b/tests/FCGI/Record/GetValuesTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace Lisachenko\Protocol\FCGI\Record;
 
 use PHPUnit\Framework\TestCase;
-use Lisachenko\Protocol\FCGI;
+use Lisachenko\Protocol\FCGI\RecordType;
 
 class GetValuesTest extends TestCase
 {
@@ -21,7 +21,7 @@ class GetValuesTest extends TestCase
     public function testPacking(): void
     {
         $request = new GetValues(['FCGI_MPXS_CONNS']);
-        $this->assertEquals(FCGI::GET_VALUES, $request->getType());
+        $this->assertSame(RecordType::GetValues, $request->getType());
         $this->assertEquals(['FCGI_MPXS_CONNS' => ''], $request->getValues());
 
         $this->assertSame(self::$rawMessage, bin2hex((string) $request));
@@ -33,7 +33,7 @@ class GetValuesTest extends TestCase
         $binaryData = hex2bin(self::$rawMessage);
         $request    = GetValues::unpack($binaryData);
 
-        $this->assertEquals(FCGI::GET_VALUES, $request->getType());
+        $this->assertSame(RecordType::GetValues, $request->getType());
         $this->assertEquals(['FCGI_MPXS_CONNS' => ''], $request->getValues());
     }
 }

--- a/tests/FCGI/Record/ParamsTest.php
+++ b/tests/FCGI/Record/ParamsTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
 
 namespace Lisachenko\Protocol\FCGI\Record;
 
-use Lisachenko\Protocol\FCGI;
+use Lisachenko\Protocol\FCGI\RecordType;
 use PHPUnit\Framework\TestCase;
 
 class ParamsTest extends TestCase
@@ -33,7 +33,7 @@ class ParamsTest extends TestCase
     public function testPacking(): void
     {
         $request = new Params(self::$params);
-        $this->assertEquals(FCGI::PARAMS, $request->getType());
+        $this->assertSame(RecordType::Params, $request->getType());
         $this->assertEquals(self::$params, $request->getValues());
 
         $this->assertSame(preg_replace('/\s+/', '', self::$rawMessage), bin2hex((string) $request));
@@ -48,7 +48,7 @@ class ParamsTest extends TestCase
         }
         $request = Params::unpack($binaryData);
 
-        $this->assertEquals(FCGI::PARAMS, $request->getType());
+        $this->assertSame(RecordType::Params, $request->getType());
         $this->assertEquals(self::$params, $request->getValues());
     }
 }

--- a/tests/FCGI/Record/ParamsTest.php
+++ b/tests/FCGI/Record/ParamsTest.php
@@ -22,7 +22,7 @@ class ParamsTest extends TestCase
         4152455048502f50726f746f636f6c2d464347490000000000';
 
     /**
-     * @var string[]
+     * @var array<string, string>
      */
     protected static array $params = [
         'SCRIPT_FILENAME'   => '/home/test.php',

--- a/tests/FCGI/Record/ParamsTest.php
+++ b/tests/FCGI/Record/ParamsTest.php
@@ -51,4 +51,32 @@ class ParamsTest extends TestCase
         $this->assertSame(RecordType::Params, $request->getType());
         $this->assertEquals(self::$params, $request->getValues());
     }
+
+    /**
+     * Names and values over 127 bytes use the long (4-byte) length form with the top bit set
+     */
+    public function testLongNameValueRoundTrip(): void
+    {
+        $name  = str_repeat('N', 150);
+        $value = str_repeat('V', 200);
+        $request = new Params([$name => $value, 'SHORT' => 'yes']);
+
+        $restored = Params::unpack((string) $request);
+
+        $this->assertSame([$name => $value, 'SHORT' => 'yes'], $restored->getValues());
+    }
+
+    /**
+     * An empty FCGI_PARAMS record marks the end of the parameter stream and is
+     * hydrated without running the constructor
+     */
+    public function testEmptyParamsRecordHasNoValues(): void
+    {
+        /** @var string $binaryData */
+        $binaryData = hex2bin('0104000100000000');
+        $record     = Params::unpack($binaryData);
+
+        $this->assertSame(RecordType::Params, $record->getType());
+        $this->assertSame([], $record->getValues());
+    }
 }

--- a/tests/FCGI/Record/StderrTest.php
+++ b/tests/FCGI/Record/StderrTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace Lisachenko\Protocol\FCGI\Record;
 
 use PHPUnit\Framework\TestCase;
-use Lisachenko\Protocol\FCGI;
+use Lisachenko\Protocol\FCGI\RecordType;
 
 class StderrTest extends TestCase
 {
@@ -22,7 +22,7 @@ class StderrTest extends TestCase
     {
         $request = new Stderr('test');
         $this->assertEquals('test', $request->getContentData());
-        $this->assertEquals(FCGI::STDERR, $request->getType());
+        $this->assertSame(RecordType::Stderr, $request->getType());
         $this->assertSame(self::$rawMessage, bin2hex((string) $request));
     }
 
@@ -31,7 +31,7 @@ class StderrTest extends TestCase
         /** @var string $binaryData */
         $binaryData = hex2bin(self::$rawMessage);
         $request    = Stderr::unpack($binaryData);
-        $this->assertEquals(FCGI::STDERR, $request->getType());
+        $this->assertSame(RecordType::Stderr, $request->getType());
         $this->assertEquals('test', $request->getContentData());
     }
 }

--- a/tests/FCGI/Record/StdinTest.php
+++ b/tests/FCGI/Record/StdinTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace Lisachenko\Protocol\FCGI\Record;
 
 use PHPUnit\Framework\TestCase;
-use Lisachenko\Protocol\FCGI;
+use Lisachenko\Protocol\FCGI\RecordType;
 
 class StdinTest extends TestCase
 {
@@ -22,7 +22,7 @@ class StdinTest extends TestCase
     {
         $request = new Stdin('test');
         $this->assertEquals('test', $request->getContentData());
-        $this->assertEquals(FCGI::STDIN, $request->getType());
+        $this->assertSame(RecordType::Stdin, $request->getType());
         $this->assertSame(self::$rawMessage, bin2hex((string) $request));
     }
 
@@ -31,7 +31,7 @@ class StdinTest extends TestCase
         /** @var string $binaryData */
         $binaryData = hex2bin(self::$rawMessage);
         $request    = Stdin::unpack($binaryData);
-        $this->assertEquals(FCGI::STDIN, $request->getType());
+        $this->assertSame(RecordType::Stdin, $request->getType());
         $this->assertEquals('test', $request->getContentData());
     }
 }

--- a/tests/FCGI/Record/StdoutTest.php
+++ b/tests/FCGI/Record/StdoutTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace Lisachenko\Protocol\FCGI\Record;
 
 use PHPUnit\Framework\TestCase;
-use Lisachenko\Protocol\FCGI;
+use Lisachenko\Protocol\FCGI\RecordType;
 
 class StdoutTest extends TestCase
 {
@@ -22,7 +22,7 @@ class StdoutTest extends TestCase
     {
         $request = new Stdout('test');
         $this->assertEquals('test', $request->getContentData());
-        $this->assertEquals(FCGI::STDOUT, $request->getType());
+        $this->assertSame(RecordType::Stdout, $request->getType());
         $this->assertSame(self::$rawMessage, bin2hex((string) $request));
     }
 
@@ -31,7 +31,7 @@ class StdoutTest extends TestCase
         /** @var string $binaryData */
         $binaryData = hex2bin(self::$rawMessage);
         $request    = Stdout::unpack($binaryData);
-        $this->assertEquals(FCGI::STDOUT, $request->getType());
+        $this->assertSame(RecordType::Stdout, $request->getType());
         $this->assertEquals('test', $request->getContentData());
     }
 }

--- a/tests/FCGI/Record/UnknownTypeTest.php
+++ b/tests/FCGI/Record/UnknownTypeTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 namespace Lisachenko\Protocol\FCGI\Record;
 
 use PHPUnit\Framework\TestCase;
-use Lisachenko\Protocol\FCGI;
+use Lisachenko\Protocol\FCGI\RecordType;
 
 class UnknownTypeTest extends TestCase
 {
@@ -21,7 +21,7 @@ class UnknownTypeTest extends TestCase
     public function testPacking(): void
     {
         $request = new UnknownType(42, 'WTF!');
-        $this->assertEquals(FCGI::UNKNOWN_TYPE, $request->getType());
+        $this->assertSame(RecordType::UnknownType, $request->getType());
         $this->assertEquals(42, $request->getUnrecognizedType());
 
         $this->assertSame(self::$rawMessage, bin2hex((string) $request));
@@ -33,7 +33,7 @@ class UnknownTypeTest extends TestCase
         $binaryData = hex2bin(self::$rawMessage);
         $request    = UnknownType::unpack($binaryData);
 
-        $this->assertEquals(FCGI::UNKNOWN_TYPE, $request->getType());
+        $this->assertSame(RecordType::UnknownType, $request->getType());
         $this->assertEquals(42, $request->getUnrecognizedType());
     }
 }

--- a/tests/FCGI/RecordTest.php
+++ b/tests/FCGI/RecordTest.php
@@ -27,7 +27,7 @@ class RecordTest extends TestCase
 
         // Verify all general fields
         $this->assertEquals(FCGI::VERSION_1, $record->getVersion());
-        $this->assertEquals(FCGI::BEGIN_REQUEST, $record->getType());
+        $this->assertSame(RecordType::BeginRequest, $record->getType());
         $this->assertEquals(1, $record->getRequestId());
         $this->assertEquals(8, $record->getContentLength());
         $this->assertEquals(0, $record->getPaddingLength());
@@ -45,7 +45,7 @@ class RecordTest extends TestCase
 
         $this->assertEquals($packet, hex2bin('010b0005000503003132333435000000'));
         $result = Record::unpack($packet);
-        $this->assertEquals(FCGI::UNKNOWN_TYPE, $result->getType());
+        $this->assertSame(RecordType::UnknownType, $result->getType());
         $this->assertEquals(5, $result->getRequestId());
         $this->assertEquals('12345', $result->getContentData());
     }


### PR DESCRIPTION
## Summary

**PR 5/6 of the library refresh stack** (agent docs ✅ → README ✅ → toolchain ✅ → PHPStan max #102 → **PHP 8.4 modernization** → CHANGELOG). Based on `chore/phpstan-level-max` — merge #102 first.

The core of the 4.0 release: a full redesign around PHP 8.4-era language features, in four commits.

### `feat!: introduce backed enums and typed instance hydration`
- **New int-backed enums** replace the `FCGI` class int constants: `RecordType` (all 11 record types, plus `recordClass()` mapping each type to its record class), `Role` (Responder/Authorizer/Filter) and `ProtocolStatus` (RequestComplete/CantMultiplexConnection/Overloaded/UnknownRole). `FCGI` keeps only the structural constants (`HEADER_LEN`, `HEADER_FORMAT`, `VERSION_1`, `NULL_REQUEST_ID`, the `KEEP_CONN` bitmask) and is now `final` with a private constructor.
- **`getType()`, `getRole()`, `getProtocolStatus()` return enums**; `BeginRequest` now requires an explicit `Role` (the old default silently meant role 3 = Filter — a latent quirk).
- **`unpackPayload()` is a protected instance method.** The old protocol — `static function unpackPayload($self, ...)` with an untyped param plus `assert()` in every subclass — existed only to work around parameter contravariance. As an instance method `$this` is naturally the concrete type; this also fixes `UnknownType::unpackPayload()` being `public` while every sibling was `protected`.
- **`ProtocolException` (extends `RuntimeException`)** replaces the mix of bare `RuntimeException`/`DomainException`. Invalid wire values (unknown record type, role, status) fail fast via `Enum::tryFrom() ?? throw`. Existing broad `catch (RuntimeException)` blocks keep working.
- Wire fidelity is preserved: unpacking still bypasses constructors (hydration), so byte-exact round-tripping holds even for non-canonical peer encodings — the untouched Wireshark hex fixtures pin this.
- Modern surface throughout: constructor property promotion, native `static` return types, `Stringable`, `final` record classes (`Params` stays open for `GetValues`/`GetValuesResult`), throw expressions, PHP 8.4 `new X()->method()` chaining.

### `perf: cache reflection and avoid buffer copies in parsing hot paths`
- `Record::unpack()` reuses a cached per-class `ReflectionClass` instead of constructing one per parsed record.
- `FrameParser::hasFrame()` unpacks only the two length fields (offset-based) instead of the whole header.
- `Params::unpackPayload()` now walks the payload with an integer cursor — the old loop made three O(n) `substr()` copies per name-value pair, quadratic on big PARAMS frames.

### `test: cover protocol errors, long name-value pairs and empty params`
New coverage: unknown record type and truncated buffer → `ProtocolException`; >127-byte names/values (4-byte long form) round-trip; empty `FCGI_PARAMS` end-of-stream marker hydrates with `getValues() === []` (this guards the one place where constructor promotion would be a correctness trap — documented in `Params` and AGENTS.md).

### `docs: update README examples and agent guidelines for the enum API`

### Deliberately not used
- `readonly` — hydration writes properties after `newInstanceWithoutConstructor()`, and mutable `setRequestId()` chaining is the documented usage pattern.
- Property hooks / asymmetric visibility — would duplicate the getter API for no gain here.

### Breaking changes (4.0)
`FCGI` type/role/status constants removed; enum-typed getters; `BeginRequest` role required; `unpackPayload()` signature; record classes `final`; `FrameParser` `final`; `ProtocolException` instead of `DomainException` for unknown types.

## Test plan

Verified locally on PHP 8.4.19: `composer test` — 31 tests, 87 assertions green; `composer phpstan` — 0 errors at level max.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PX3K7p5AYfoVmtED88AAKv)_