### PR TITLE
ci: add experimental PHP 8.6 nightly job to the build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,17 @@ jobs:
   phpunit:
     name: "PHPUnit (PHP ${{ matrix.php }}, ${{ matrix.dependencies }})"
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental || false }}
     strategy:
       fail-fast: false
       matrix:
         php: ["8.4", "8.5"]
         dependencies: [lowest, highest]
+        include:
+          # Early warning for the next PHP minor (nightly build, non-blocking)
+          - php: "8.6"
+            dependencies: highest
+            experimental: true
     steps:
       - uses: actions/checkout@v7
 


### PR DESCRIPTION
## Summary

Follow-up to the refresh stack: the stable build matrix is already current (PHP 8.4 + 8.5 × lowest/highest dependencies, with dependabot keeping the actions pinned), so the only meaningful addition is forward-coverage.

- Adds a **PHP 8.6 (nightly)** entry to the PHPUnit matrix via `include`, running with highest dependencies only.
- The job is marked `experimental` and the `phpunit` job gets `continue-on-error: ${{ matrix.experimental || false }}` — a red 8.6 nightly never blocks a PR, it's purely an early warning for the next PHP minor (due Nov 2026). Stable jobs are unaffected (`|| false` keeps them blocking).
- Independent of the open stack PRs (#103, #106) — based directly on `master`, no conflicts (they don't touch `ci.yml`).

## Test plan

The updated workflow runs on this PR itself: expect the four stable jobs green as before, plus the new non-blocking `PHPUnit (PHP 8.6, highest)` job (nightly builds are provided by `shivammathur/setup-php`; `>=8.4` and PHPUnit 12's `>=8.3` platform constraints are satisfied by `8.6.0-dev`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PX3K7p5AYfoVmtED88AAKv)_