### PR TITLE
docs: show PHP >= 8.4 in the minimum PHP version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Latest Version](https://img.shields.io/packagist/v/lisachenko/protocol-fcgi.svg)](https://packagist.org/packages/lisachenko/protocol-fcgi)
 [![Total Downloads](https://img.shields.io/packagist/dt/lisachenko/protocol-fcgi.svg)](https://packagist.org/packages/lisachenko/protocol-fcgi)
 [![Daily Downloads](https://img.shields.io/packagist/dd/lisachenko/protocol-fcgi.svg)](https://packagist.org/packages/lisachenko/protocol-fcgi)
-[![Minimum PHP Version](https://img.shields.io/packagist/dependency-v/lisachenko/protocol-fcgi/php.svg?colorB=8892BF)](https://www.php.net/supported-versions.php)
+[![Minimum PHP Version](https://img.shields.io/badge/php-%3E%3D%208.4-8892BF.svg)](https://www.php.net/supported-versions.php)
 [![License](https://img.shields.io/packagist/l/lisachenko/protocol-fcgi.svg)](https://packagist.org/packages/lisachenko/protocol-fcgi)
 
 A **zero-dependency, object-oriented implementation of the FastCGI 1.0 binary protocol** for PHP.


### PR DESCRIPTION
## Summary

- Replaces the dynamic Packagist dependency badge (`packagist/dependency-v/.../php`) with a static shields.io badge reading **php >= 8.4** (same style as goaop/framework), linked to php.net's supported-versions page.
- Reason: the Packagist badge reflects the *latest tagged release* — until `4.0.0` is published it still advertises the old `^7.4||^8.0` constraint, contradicting the code on master. The static badge shows the actual current requirement immediately.

If you'd prefer the badge to track composer.json automatically again after the 4.0.0 release is on Packagist, it's a one-line revert.

## Test plan

Documentation only — badge renders as `php >= 8.4` in the README header.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PX3K7p5AYfoVmtED88AAKv)_